### PR TITLE
fix 404 error for "Upload Theme" link

### DIFF
--- a/wp-appkit/lib/themes/themes-bo-settings.php
+++ b/wp-appkit/lib/themes/themes-bo-settings.php
@@ -37,7 +37,7 @@ class WpakThemesBoSettings {
 				<strong><?php _e( 'No WP AppKit theme found!', WpAppKit::i18n_domain ) ?></strong>
 				<br/>
 				<?php echo  sprintf( __('Please upload a WP AppKit theme from the "<a href="%s" >Upload Themes</a>" panel or copy a theme directly to the %s directory.', WpAppKit::i18n_domain ),
-									'/wp-admin/admin.php?page=wpak_bo_upload_themes',
+									admin_url('admin.php?page=wpak_bo_upload_themes'),
 									basename(WP_CONTENT_DIR) .'/'. WpakThemes::themes_directory
 							)
 				?>


### PR DESCRIPTION
Use `admin_url` function instead of hard coded value for "Upload Themes" link to avoid 404 error when WordPress folder has been moved (in a subfolder for example)